### PR TITLE
Feat/change package name by path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -330,10 +330,31 @@ private:
 
       std::string global_frame = namespace_iterator->second["global_frame"].as<std::string>();
       YAML::Node maps = namespace_iterator->second["maps"];
-
       new_environment.name = namespace_iterator->first.as<std::string>();
       new_environment.global_frame = global_frame;
+      std::string map_path_root="";
 
+      try 
+      {
+        map_path_root = ros::package::getPath(namespace_iterator->second["maps_package"].as<std::string>());
+        ROS_WARN("maps_package field is deprecated. Please use maps_path instead");
+      } catch (YAML::Exception) 
+      {
+        //ROS_INFO_STREAM("maps_package key does not exist");
+        try 
+        {
+          //ROS_INFO_STREAM("map_path_root = " << map_path_root);
+          map_path_root = namespace_iterator->second["maps_path"].as<std::string>();
+        }
+        catch (YAML::Exception) 
+        {
+          ROS_ERROR("maps_package nor maps_path field are defined");
+          exit(-1);
+        }
+      }
+      ROS_INFO_STREAM("map_path_root = " << map_path_root);
+      
+      
       bool maps_loaded = true;
       bool maps_already_loaded = false;
       for (YAML::const_iterator maps_iterator = maps.begin(); maps_iterator != maps.end(); ++maps_iterator)
@@ -341,8 +362,7 @@ private:
         //std::string map_path = ros::package::getPath(namespace_iterator->second["maps_package"].as<std::string>()) +
         //                       "/" + maps_iterator->second.as<std::string>();
         // maps package is used as maps_folder_package in order to be able to locate the files anywhere
-        std::string map_path = namespace_iterator->second["maps_package"].as<std::string>() +
-                               "/" + maps_iterator->second.as<std::string>();
+        std::string map_path = map_path_root + "/" + maps_iterator->second.as<std::string>();
         std::string map_namespace = namespace_iterator->first.as<std::string>();
         std::string map_name = maps_iterator->first.as<std::string>();
         std::string map_frame = namespace_iterator->second["global_frame"].as<std::string>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -338,7 +338,10 @@ private:
       bool maps_already_loaded = false;
       for (YAML::const_iterator maps_iterator = maps.begin(); maps_iterator != maps.end(); ++maps_iterator)
       {
-        std::string map_path = ros::package::getPath(namespace_iterator->second["maps_package"].as<std::string>()) +
+        //std::string map_path = ros::package::getPath(namespace_iterator->second["maps_package"].as<std::string>()) +
+        //                       "/" + maps_iterator->second.as<std::string>();
+        // maps package is used as maps_folder_package in order to be able to locate the files anywhere
+        std::string map_path = namespace_iterator->second["maps_package"].as<std::string>() +
                                "/" + maps_iterator->second.as<std::string>();
         std::string map_namespace = namespace_iterator->first.as<std::string>();
         std::string map_name = maps_iterator->first.as<std::string>();


### PR DESCRIPTION
This PR aims to enable the use of global paths for setting the maps path instead of depending on a ROS package.

This pull request includes changes to the `MultimapServer` class in `src/main.cpp` to handle deprecated fields and improve error handling when retrieving map paths.

Error handling and deprecation warnings:

* Added a new block to handle the deprecated `maps_package` field and issue a warning if it is used. (`src/main.cpp`, [src/main.cppL333-R365](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L333-R365))
* Implemented error handling to check for the existence of `maps_path` if `maps_package` is not defined, and log an error if neither is present, terminating the program. (`src/main.cpp`, [src/main.cppL333-R365](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L333-R365))

Code simplification:

* Removed the hardcoded retrieval of the map path using `maps_package` and replaced it with a dynamically determined `map_path_root`. (`src/main.cpp`, [src/main.cppL333-R365](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L333-R365))